### PR TITLE
bugfix for creditcard accounts in Client.py

### DIFF
--- a/ofxtools/Client.py
+++ b/ofxtools/Client.py
@@ -97,7 +97,7 @@ class BankAcct(object):
 
 class CcAcct(BankAcct):
     """ """
-    acctkeys = ('ACCTID')
+    acctkeys = ('ACCTID',)
     acctfrom_tag = 'CCACCTFROM'
     stmtrq_tag = 'CCSTMTRQ'
     msgsrq_tag = 'CREDITCARDMSGSRQV1'


### PR DESCRIPTION
acctkeys should be a 1-tuple, not a string.
